### PR TITLE
Update GitHub link in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,8 +39,8 @@ Anything surrounded by a dark orange dotted line is added to the page by this pl
 ## Get started (Development)
 
 1. Clone this repository
-   `git clone https://github.com/garyhtou/hcb-ops-plugin`
-2. `cd hcb-ops-plugin`
+   `git clone https://github.com/hackclub/bank-ops-plugin`
+2. `cd bank-ops-plugin`
 3. `npm install`
 4. `npx webpack -w`
 5. The unpacked Chrome extension will be compiled into `dist/`. You can load it into Chrome by enabling developer mode on the "Extensions" page, hitting "Load unpacked", and selecting the `dist/` folder. After an edit, you will need to reload the chrome extension by clicking the icon next to the extension's on/off switch.


### PR DESCRIPTION
Seems like the ownership changed & the repo was renamed. This updates the README to reflect that change.